### PR TITLE
openmq: do not use authentication if user is null or empty.

### DIFF
--- a/org.titou10.jtb.qm.openmq/src/org/titou10/jtb/qm/openmq/OpenMQQManager.java
+++ b/org.titou10.jtb.qm.openmq/src/org/titou10/jtb/qm/openmq/OpenMQQManager.java
@@ -133,7 +133,12 @@ public class OpenMQQManager extends QManager {
          AdminConnectionFactory acf = new AdminConnectionFactory();
          acf.setProperty(AdminConnectionConfiguration.imqAddress, serviceURL);
 
-         JMXConnector jmxc = acf.createConnection(sessionDef.getActiveUserid(), sessionDef.getActivePassword());
+         JMXConnector jmxc;
+         if (sessionDef.getActiveUserid() == null || sessionDef.getActiveUserid().trim().isEmpty()) {
+            jmxc = acf.createConnection();
+         } else {
+            jmxc = acf.createConnection(sessionDef.getActiveUserid(), sessionDef.getActivePassword());
+         } 
          MBeanServerConnection mbsc = jmxc.getMBeanServerConnection();
 
          // // Connect using standard JMX
@@ -153,7 +158,12 @@ public class OpenMQQManager extends QManager {
          ConnectionFactory cf = new ConnectionFactory();
          cf.setProperty(ConnectionConfiguration.imqAddressList, serviceURL);
 
-         Connection jmsConnection = cf.createConnection(sessionDef.getActiveUserid(), sessionDef.getActivePassword());
+         Connection jmsConnection;
+         if (sessionDef.getActiveUserid() == null || sessionDef.getActiveUserid().trim().isEmpty()) {
+            jmsConnection = cf.createConnection();
+         } else {
+            jmsConnection = cf.createConnection(sessionDef.getActiveUserid(), sessionDef.getActivePassword());
+         }
          jmsConnection.setClientID(clientID);
          jmsConnection.start();
 


### PR DESCRIPTION
## Fixes bug...
- OpenMQ authentication exception when no username/password was provided from the UI.

## New Features ...
- Add the ability to connect to an unauthenticated OpenMQ instance. 

## Description of proposed Change
  - If the user doesn't specify a username in the connection's options, the MQ Manager will not try to use authentication.
