### PR TITLE
Refresh of queue messages when max messages is modified.

### DIFF
--- a/org.titou10.jtb.core/src/org/titou10/jtb/ui/part/content/JTBSessionContentViewPart.java
+++ b/org.titou10.jtb.core/src/org/titou10/jtb/ui/part/content/JTBSessionContentViewPart.java
@@ -686,6 +686,10 @@ public class JTBSessionContentViewPart {
                td.maxMessages = spinnerMaxMessages.getSelection();
             }
          });
+         spinnerMaxMessages.addSelectionListener(SelectionListener.widgetDefaultSelectedAdapter(event -> {
+            TabData td2 = (TabData) tabFolder.getSelection().getData();
+            eventBroker.send(Constants.EVENT_REFRESH_QUEUE_MESSAGES, td2.jtbDestination.getAsJTBQueue());
+         })); 
 
          // Columns Sets
          ColumnsSet cs = csManager.getDefaultColumnSet(jtbQueue).columnsSet;


### PR DESCRIPTION


## Fixes bug...

## New Features ...
Upon confirming a new number of maximum messages to be displayed for a specific queue, the queue messages view is now refreshed.

## Description of proposed Change
Added a selection listener to the max messages spinner that sends the "refresh queue messages" event.
