### PR TITLE
Fix cursor positioning and unintentionally selected text.

### DIFF
--- a/org.titou10.jtb.core/src/org/titou10/jtb/ui/hex/BinaryTextBox.java
+++ b/org.titou10.jtb.core/src/org/titou10/jtb/ui/hex/BinaryTextBox.java
@@ -243,7 +243,6 @@ abstract class BinaryTextBox {
       if (txtCharWidth <= 0) {
          txtCharWidth = FontUtils.getFontCharWidth(txt);
       }
-      System.out.println("width=" + txtCharWidth);
       return txtCharWidth;
    }
 
@@ -251,7 +250,6 @@ abstract class BinaryTextBox {
       if (txtCharHeight <= 0) {
          txtCharHeight = FontUtils.getFontCharHeight(txt);
       }
-      System.out.println("height=" + txtCharHeight);
       return txtCharHeight;
    }
 

--- a/org.titou10.jtb.core/src/org/titou10/jtb/ui/hex/BinaryTextBox.java
+++ b/org.titou10.jtb.core/src/org/titou10/jtb/ui/hex/BinaryTextBox.java
@@ -14,22 +14,23 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
+import org.titou10.jtb.util.FontUtils;
 
 abstract class BinaryTextBox {
-   static int                 CHAR_HEIGHT = 17; // the number of pixels a char actually takes
-   static int                 CHAR_WIDTH  = 10; // the number of pixels a char actually takes
+   int txtCharHeight;
+   double txtCharWidth;
 
-   protected StyledText       txt;
-   protected HexViewer        hex;
+   protected StyledText txt;
+   protected HexViewer hex;
 
-   protected int              rowsInView;
-   protected int              bytesPerRow;
-   protected int              charsPerRow;
-   protected int              beforePos[];
-   protected int              afterPos[];
+   protected int rowsInView;
+   protected int bytesPerRow;
+   protected int charsPerRow;
+   protected int beforePos[];
+   protected int afterPos[];
 
-   protected Byte             rowTemp[];
-   protected StringBuilder    sbTemp;
+   protected Byte rowTemp[];
+   protected StringBuilder sbTemp;
    protected List<StyleRange> styleRanges;
 
    public BinaryTextBox(final HexViewer hex, int bpr) {
@@ -53,36 +54,42 @@ abstract class BinaryTextBox {
          }
 
          public void mouseDown(MouseEvent e) {
-            int ca = getAddressByPos(getCaretPos(e.x, e.y));
-            hex.setSelectEnd(ca);
-            if ((e.stateMask & SWT.SHIFT) == 0) {
-               hex.setSelectStart(ca);
+            if (txt.isFocusControl()) {
+               int ca = getAddressByPos(getCaretPos(e.x, e.y));
+               hex.setSelectEnd(ca);
+               if ((e.stateMask & SWT.SHIFT) == 0) {
+                  hex.setSelectStart(ca);
+               }
+               hex.showSelection();
+               txt.setFocus();
             }
-            hex.showSelection();
-            txt.setFocus();
          }
 
          public void mouseUp(MouseEvent e) {
-            int ca = getAddressByPos(getCaretPos(e.x, e.y));
-            hex.setSelectEnd(ca);
-            hex.showSelection();
-            txt.setFocus();
+            if (txt.isFocusControl()) {
+               int ca = getAddressByPos(getCaretPos(e.x, e.y));
+               hex.setSelectEnd(ca);
+               hex.showSelection();
+               txt.setFocus();
+            }
          }
       });
       txt.addMouseMoveListener(new MouseMoveListener() {
          public void mouseMove(MouseEvent e) {
-            if ((e.stateMask & SWT.BUTTON1) != 0) {
-               int ca = getAddressByPos(getCaretPos(e.x, e.y));
-               hex.setSelectEnd(ca);
-               // scroll if out of bounds
-               if (e.y < 0) {
-                  hex.setShowStart(hex.getShowStart() - 1);
-               } else
-                  if (e.y > txt.getSize().y) {
+            if (txt.isFocusControl()) {
+               if ((e.stateMask & SWT.BUTTON1) != 0) {
+                  int ca = getAddressByPos(getCaretPos(e.x, e.y));
+                  hex.setSelectEnd(ca);
+                  // scroll if out of bounds
+                  if (e.y < 0) {
+                     hex.setShowStart(hex.getShowStart() - 1);
+                  } else
+                     if (e.y > txt.getSize().y) {
                      hex.setShowStart(hex.getShowStart() + 1);
                   }
-               hex.showSelection();
-               txt.setFocus();
+                  hex.showSelection();
+                  txt.setFocus();
+               }
             }
          }
       });
@@ -99,32 +106,32 @@ abstract class BinaryTextBox {
 
          // move the caret according to key
          switch (e.keyCode) {
-            case SWT.ARROW_DOWN:
-               caretAddress = caretAddress + bytesPerRow;
-               break;
-            case SWT.ARROW_UP:
-               caretAddress = caretAddress - bytesPerRow;
-            case SWT.ARROW_RIGHT:
-               caretAddress = caretAddress + 1;
-               break;
-            case SWT.ARROW_LEFT:
-               caretAddress = caretAddress - 1;
-               break;
-            case SWT.PAGE_DOWN:
-               caretAddress = caretAddress + bytesPerRow * rowsInView;
-               break;
-            case SWT.PAGE_UP:
-               caretAddress = caretAddress - bytesPerRow * rowsInView;
-               break;
-            case SWT.HOME:
-               caretAddress = 0;
-               break;
-            case SWT.END:
-               caretAddress = hex.getDataSize();
-               break;
-            default:
-               // no traversal key
-               return;
+         case SWT.ARROW_DOWN:
+            caretAddress = caretAddress + bytesPerRow;
+            break;
+         case SWT.ARROW_UP:
+            caretAddress = caretAddress - bytesPerRow;
+         case SWT.ARROW_RIGHT:
+            caretAddress = caretAddress + 1;
+            break;
+         case SWT.ARROW_LEFT:
+            caretAddress = caretAddress - 1;
+            break;
+         case SWT.PAGE_DOWN:
+            caretAddress = caretAddress + bytesPerRow * rowsInView;
+            break;
+         case SWT.PAGE_UP:
+            caretAddress = caretAddress - bytesPerRow * rowsInView;
+            break;
+         case SWT.HOME:
+            caretAddress = 0;
+            break;
+         case SWT.END:
+            caretAddress = hex.getDataSize();
+            break;
+         default:
+            // no traversal key
+            return;
          }
 
          caretAddress = HexViewer.fix(caretAddress, hex.getDataSize());
@@ -141,8 +148,8 @@ abstract class BinaryTextBox {
    }
 
    protected int getCaretPos(int x, int y) {
-      int row = y / CHAR_HEIGHT;
-      int col = x / CHAR_WIDTH;
+      int row = y / getCharHeight();
+      int col = (int) Math.round(x / getCharWidht());
       return row * charsPerRow + col;
    }
 
@@ -224,7 +231,7 @@ abstract class BinaryTextBox {
    public int calcRowsInView() {
       // use -10 due to border width, and some extra spacing
       // rowsInView = (txt.getSize().y - 10) / CHAR_HEIGHT;
-      rowsInView = (txt.getParent().getSize().y - 10) / CHAR_HEIGHT;
+      rowsInView = (txt.getParent().getSize().y - 10) / getCharHeight();
       return rowsInView;
    }
 
@@ -232,10 +239,26 @@ abstract class BinaryTextBox {
       this.rowsInView = rows;
    }
 
+   private double getCharWidht() {
+      if (txtCharWidth <= 0) {
+         txtCharWidth = FontUtils.getFontCharWidth(txt);
+      }
+      System.out.println("width=" + txtCharWidth);
+      return txtCharWidth;
+   }
+
+   private int getCharHeight() {
+      if (txtCharHeight <= 0) {
+         txtCharHeight = FontUtils.getFontCharHeight(txt);
+      }
+      System.out.println("height=" + txtCharHeight);
+      return txtCharHeight;
+   }
+
    private int getWidth() {
       if (afterPos == null) {
          return 0;
       }
-      return afterPos[bytesPerRow - 1] * CHAR_WIDTH + 5;
+      return (int) Math.round(afterPos[bytesPerRow - 1] * getCharWidht() + 5);
    }
 }

--- a/org.titou10.jtb.core/src/org/titou10/jtb/util/FontUtils.java
+++ b/org.titou10.jtb.core/src/org/titou10/jtb/util/FontUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 Denis Forveille titou10.titou10@gmail.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.titou10.jtb.util;
+
+import org.eclipse.swt.graphics.Drawable;
+import org.eclipse.swt.graphics.FontMetrics;
+import org.eclipse.swt.graphics.GC;
+
+public final class FontUtils {
+
+   /*
+    * http://www.java2s.com/Tutorial/Java/0300__SWT-2D-Graphics/
+    * UsingFontMetricstogetcharwidth.htm (FontMetricsCharWidth)
+    */
+   public static double getFontCharWidth(Drawable aDrawable) {
+      GC gc = null;  
+      try {
+         gc = new GC(aDrawable);
+         FontMetrics fm = gc.getFontMetrics();
+         double charWidth = fm.getAverageCharacterWidth();
+         return charWidth;
+      } finally {
+         if (gc != null) {
+            gc.dispose();
+         }
+      }
+   }
+
+   /*
+    * http://www.java2s.com/Tutorial/Java/0300__SWT-2D-Graphics/
+    * UsingFontMetricstogetcharwidth.htm (FontMetricsCharWidth)
+    */
+   public static int getFontCharHeight(Drawable aDrawable) {
+      GC gc = null;
+      try {
+         gc = new GC(aDrawable);
+         FontMetrics fm = gc.getFontMetrics();
+         int charHeight = fm.getHeight();
+         return charHeight;
+      } finally {
+         if (gc != null) {
+            gc.dispose();
+         }
+      }
+   }
+
+}


### PR DESCRIPTION
## Bug fixes
- Fixed unexpected text selection.
  Steps to reproduce the problem:
  - Select **Send New Message...** on a given queue.
  - Select the **Payload** tab.
  - Select type **Bytes**.
  - Click **Import...** to open the **Select File** dialog.
  - Ensure that the **Select File** dialog is placed over the hex editor area of the message editor.
    Actually the file that will be selected, must be over the hex editor area of the message editor.
  - **Important:** select the file with a mouse double-click.
  - The bytes displayed in the hex editor will be selected from the first byte to the last byte. The
    last byte is the byte where the double-click in the **Select File** dialog occurred.
- Fixed problem, that the cursor was not correctly positioned in the "Bytes" message editor on a mouse click.
  Steps to reproduce the problem:
  - Select **Send New Message...** on a given queue.
  - Select the **Payload** tab.
  - Select type **Bytes**.
  - Import a message from the file system.
  - Click on the first byte of the message editor. Cursor is correctly positioned.
  - Click on the eight byte of the message editor. Cursor is positioned on the seventh byte.
  - Click on the sixteenth byte of the message editor. Cursor is positioned on the thirteenth byte.
  - Reason: **CHAR_HEIGHT** and **CHAR_WIDTH** are set to fix values instead of being calculated depending on the font.
