### PR TITLE
Fix incorrect tooltip text.

### DIFF
--- a/org.titou10.jtb.core/src/org/titou10/jtb/dialog/MessageDialogAbstract.java
+++ b/org.titou10.jtb.core/src/org/titou10/jtb/dialog/MessageDialogAbstract.java
@@ -398,11 +398,11 @@ public abstract class MessageDialogAbstract extends Dialog {
       lblNewLabel9.setText("Open as:");
 
       comboVisualizers = new Combo(cVisualizer, SWT.READ_ONLY);
-      comboMessageType.setToolTipText("Choose visualizer");
+      comboVisualizers.setToolTipText("Choose visualizer");
 
       btnShowAs = new Button(cVisualizer, SWT.CENTER);
       btnShowAs.setImage(SWTResourceManager.getImage(this.getClass(), "icons/messages/zoom.png"));
-      comboMessageType.setToolTipText("Run visuzlizer");
+      btnShowAs.setToolTipText("Run visualizer");
 
       // Formatting Buttons
 
@@ -471,7 +471,7 @@ public abstract class MessageDialogAbstract extends Dialog {
       btnExport = new Button(cImportExport, SWT.CENTER);
       btnExport.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1));
       btnExport.setText("Export...");
-      btnImport.setToolTipText("Export Payload");
+      btnExport.setToolTipText("Export Payload");
       btnExport.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
          try {
             Utils.exportPayloadToOS(getShell(), template, txtPayload.getText(), payloadBytes, payloadMap);


### PR DESCRIPTION
## Bug fix
- Fix incorrect tooltip texts in the **Send Message** dialog.
  Steps to reproduce the problem:
  -  Select Send New Message... on a given queue.
  - Select the Payload tab.
  - Hover over the **Type** combo box. Tooltip: *Run visuzlizer*
  - Hover over the **Open as** combo box. Tooltip: -/-
  - Hover over the **Show as** button. Tooltip: -/-
  - Hover over the **Import...** button. Tooltip: *Export Payload*
  - Hover over the **Export...** button. Tooltip: -/-
