### PR TITLE
Remove debug statements.

### DIFF
--- a/org.titou10.jtb.core/src/org/titou10/jtb/ui/hex/AbstractDataProvider.java
+++ b/org.titou10.jtb.core/src/org/titou10/jtb/ui/hex/AbstractDataProvider.java
@@ -46,9 +46,6 @@ public class AbstractDataProvider implements IDataProvider {
       for (; i < bytesPerRow; i++) {
          arr[i] = null;
       }
-      if (rowNumber == 5) {
-         arr[7] = null;
-      }
       return res;
    }
 


### PR DESCRIPTION
## Bug fix
- Remove debug statement from `AbstractDataProvider`.
  The AbstractDataProvider sets the 104th byte (row=5, column=7) to **null**. I assume that these statements had been added for debugging purposes.
  Steps to reproduce the problem:
  - Select a queue with **Byte** messages.
  - In the message list, jump between the messages and watch the **Payload** tab.
  - On each message bthe 104th byte is **null** (displayed as '??').