### PR TITLE
Fix NullPointerException and export with character set UTF-8.

### DIFF
--- a/org.titou10.jtb.core/src/org/titou10/jtb/dialog/MessageDialogAbstract.java
+++ b/org.titou10.jtb.core/src/org/titou10/jtb/dialog/MessageDialogAbstract.java
@@ -442,19 +442,15 @@ public abstract class MessageDialogAbstract extends Dialog {
       btnImport.setToolTipText("Import Payload");
       btnImport.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
          try {
-            var b = Utils.readFileBytes(getShell());
-            if (b == null) {
-               return;
-            }
             switch (jtbMessageType) {
                case TEXT:
-                  var payloadText = new String(b);
+                  String payloadText = Utils.readFileText(getShell());
                   txtPayload.setText(payloadText);
                   tbtmPayload.setText(String.format(Constants.PAYLOAD_TEXT_TITLE, payloadText.length()));
                   break;
                case BYTES:
-                  payloadBytes = b;
-                  IDataProvider idp = new BytesDataProvider(b);
+                  payloadBytes = Utils.readFileBytes(getShell());
+                  IDataProvider idp = new BytesDataProvider(payloadBytes);
                   hvPayLoadHex.setDataProvider(idp);
                   tbtmPayload.setText(String.format(Constants.PAYLOAD_BYTES_TITLE, idp.getDataSize()));
                   break;

--- a/org.titou10.jtb.core/src/org/titou10/jtb/handler/MessageSendHandler.java
+++ b/org.titou10.jtb.core/src/org/titou10/jtb/handler/MessageSendHandler.java
@@ -205,12 +205,12 @@ public class MessageSendHandler {
                            switch (type) {
                               case BYTES:
                                  template.setJtbMessageType(JTBMessageType.BYTES);
-                                 template.setPayloadBytes(Files.readAllBytes(Paths.get(fileName)));
+                                 template.setPayloadBytes(Utils.readFileBytes(fileName));
                                  break;
 
                               default:
                                  template.setJtbMessageType(JTBMessageType.TEXT);
-                                 template.setPayloadText(new String(Files.readAllBytes(Paths.get(fileName))));
+                                 template.setPayloadText(Utils.readFileText(fileName));
                                  break;
                            }
                         }

--- a/org.titou10.jtb.core/src/org/titou10/jtb/script/ScriptExecutionEngine.java
+++ b/org.titou10.jtb.core/src/org/titou10/jtb/script/ScriptExecutionEngine.java
@@ -298,11 +298,11 @@ public class ScriptExecutionEngine {
          for (File file : payloadFiles) {
             switch (jtbMessageTemplate.getJtbMessageType()) {
                case TEXT:
-                  jtbMessageTemplate.setPayloadText(new String(Files.readAllBytes(file.toPath())));
+                  jtbMessageTemplate.setPayloadText(Utils.readFileText(file.getAbsolutePath()));
                   break;
 
                case BYTES:
-                  jtbMessageTemplate.setPayloadBytes(Files.readAllBytes(file.toPath()));
+                  jtbMessageTemplate.setPayloadBytes(Utils.readFileBytes(file.getAbsolutePath()));
                   break;
 
                default:

--- a/org.titou10.jtb.core/src/org/titou10/jtb/template/TemplatesManager.java
+++ b/org.titou10.jtb.core/src/org/titou10/jtb/template/TemplatesManager.java
@@ -400,7 +400,6 @@ public class TemplatesManager {
                                                                         false)
                            + Constants.JTB_TEMPLATE_FILE_EXTENSION;
          log.debug("choosenFileName={}", choosenFileName);
-         java.nio.file.Path destPath = Paths.get(choosenFileName);
 
          // Marshall the template to xml
          Marshaller m = jcJTBMessageTemplate.createMarshaller();
@@ -410,7 +409,7 @@ public class TemplatesManager {
          try (ByteArrayOutputStream baos = new ByteArrayOutputStream(BUFFER_SIZE)) {
             m.marshal(jtbMessageTemplate, baos);
             log.debug("write template {}. xml file size :  {} bytes.", choosenFileName, baos.size());
-            Files.write(destPath, baos.toByteArray());
+            Utils.writeFile(choosenFileName, baos);
             nb++;
          }
       }
@@ -447,8 +446,6 @@ public class TemplatesManager {
       String choosenFileName = sb2.toString();
       log.debug("choosenFileName={}", choosenFileName);
 
-      java.nio.file.Path destPath = Paths.get(choosenFileName);
-
       // Marshall the template to xml
       Marshaller m = jcJTBMessageTemplate.createMarshaller();
       m.setProperty(Marshaller.JAXB_ENCODING, ENC);
@@ -457,7 +454,7 @@ public class TemplatesManager {
       try (ByteArrayOutputStream baos = new ByteArrayOutputStream(BUFFER_SIZE)) {
          m.marshal(jtbMessageTemplate, baos);
          log.debug("xml file size :  {} bytes.", baos.size());
-         Files.write(destPath, baos.toByteArray());
+         Utils.writeFile(choosenFileName, baos);
       }
    }
 


### PR DESCRIPTION
## Bug fixes
- Fixed NullPointerException if exporting message payload from the message dialog.
  Steps to reproduce the problem:
  - Double click an existing message.
  - Click the **Export** button on the **Payload** tab.
  - Enter a file name on the **Select File** dialog and click the **Save** button.
  - Java exception:
  ```text
  java.lang.NullPointerException: Cannot invoke "org.titou10.jtb.jms.model.JTBMessage.getJtbMessageType()" because 
  "jtbMessage" is null
        at org.titou10.jtb.util.Utils.exportPayloadToOS(Utils.java:315)
        at org.titou10.jtb.util.Utils.exportPayloadToOS(Utils.java:267)
        at org.titou10.jtb.dialog.MessageDialogAbstract.lambda$3(MessageDialogAbstract.java:477)
        at org.eclipse.swt.events.SelectionListener$1.widgetSelected(SelectionListener.java:84)
        at org.eclipse.swt.widgets.TypedListener.handleEvent(TypedListener.java:252)
        at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
        at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4274)
        at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1066)
        at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:4072)
        at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3660)
        at org.eclipse.jface.window.Window.runEventLoop(Window.java:823)
        at org.eclipse.jface.window.Window.open(Window.java:799)
        at org.titou10.jtb.handler.MessageViewHandler.execute(MessageViewHandler.java:100)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.eclipse.e4.core.internal.di.MethodRequestor.execute(MethodRequestor.java:58)
        at org.eclipse.e4.core.internal.di.InjectorImpl.invokeUsingClass(InjectorImpl.java:298)
        at org.eclipse.e4.core.internal.di.InjectorImpl.invoke(InjectorImpl.java:232)
        at org.eclipse.e4.core.contexts.ContextInjectionFactory.invoke(ContextInjectionFactory.java:174)
        at org.eclipse.e4.core.commands.internal.HandlerServiceHandler.execute(HandlerServiceHandler.java:165)
        at org.eclipse.core.commands.Command.executeWithChecks(Command.java:488)
        at org.eclipse.core.commands.ParameterizedCommand.executeWithChecks(ParameterizedCommand.java:485)
        at org.eclipse.e4.core.commands.internal.HandlerServiceImpl.executeHandler(HandlerServiceImpl.java:204)
        at org.eclipse.e4.core.commands.internal.HandlerServiceImpl.executeHandler(HandlerServiceImpl.java:186)
        at org.titou10.jtb.ui.part.content.JTBSessionContentViewPart$10.doubleClick(JTBSessionContentViewPart.java:767)
        at org.eclipse.jface.viewers.StructuredViewer$1.run(StructuredViewer.java:779)
        at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
        at org.eclipse.jface.util.SafeRunnable.run(SafeRunnable.java:174)
        at org.eclipse.jface.viewers.StructuredViewer.fireDoubleClick(StructuredViewer.java:776)
        at org.eclipse.jface.viewers.StructuredViewer.handleDoubleSelect(StructuredViewer.java:1092)
        at org.eclipse.jface.viewers.ColumnViewer.handleDoubleSelect(ColumnViewer.java:1033)
        at org.eclipse.jface.viewers.StructuredViewer$4.widgetDefaultSelected(StructuredViewer.java:1205)
        at org.eclipse.jface.util.OpenStrategy.fireDefaultSelectionEvent(OpenStrategy.java:271)
        at org.eclipse.jface.util.OpenStrategy$1.handleEvent(OpenStrategy.java:328)
        at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
        at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4274)
        at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1066)
        at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:4072)
        at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3660)
        at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1151)
        at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
        at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1042)
        at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:152)
        at org.eclipse.e4.ui.internal.workbench.swt.E4Application.start(E4Application.java:165)
        at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:208)
        at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:143)
        at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:109)
        at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:439)
        at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:271)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:651)
        at org.eclipse.equinox.launcher.Main.basicRun(Main.java:588)
        at org.eclipse.equinox.launcher.Main.run(Main.java:1459)
        at org.eclipse.equinox.launcher.Main.main(Main.java:1432)
  ```

- Fixed bug that payloads with Polish special characters cloud not be exported on a German Windows.
  The problem is that some characters could not be translated and stored in character set windows-1252.
  The issue was resolved by ensuring that messages are saved using the UTF-8 character set.
  Steps to reproduce the problem:
  - Double click a message of type **Json** or **Text** with special characters that cannot be displayed with character set windows-1252, e.g. **Jabłonna**, **Zegrzyńska** and **Michał**. The characters that cannot be displayed are; "ł", "ń" and "ł".
  - Select the **Payload** tab and click the **Export** button.
  - The message is stored like this:

```json
{
   "Location": "Jab?onna ul. Zegrzy?ska",
   "First name": "Micha?",
   "Lastname": "Bukowski"
}
```
  - The correct format is:
```json
{
   "Location": "Jabłonna ul. Zegrzyńska",
   "First name": "Michał",
   "Lastname": "Bukowski"
}
```
  - I fix the issue and refactored class `org.titou10.jtb.util.Utils`. Now all _read_/_write_ operations of the application use the specialized _readFile*_/_writeFile*_ methods of class `Utils`.
  - It would be easy to add preferences options for selecting the required encoding like the Eclipse properties on the **General 
  - Workspace** tab, option **Text file encoding**. For now the encoding is hardcoded as `StandardCharsets.UTF_8`.
