### PR TITLE
feat(oracleaq): show exception queue based on property

### DIFF
--- a/org.titou10.jtb.core/src/org/titou10/jtb/jms/model/JTBConnection.java
+++ b/org.titou10.jtb.core/src/org/titou10/jtb/jms/model/JTBConnection.java
@@ -267,7 +267,7 @@ public class JTBConnection {
       Collections.sort(metaJMSPropertyNames);
 
       // Build lists of destinations
-      DestinationData dd = qm.discoverDestinations(jmsConnection, showSystemObjects);
+      DestinationData dd = qm.discoverDestinations(jmsConnection, showSystemObjects, sessionDef);
       for (QueueData qData : dd.getListQueueData()) {
          log.debug("jmsSession.createQueue '{}'", qData.getName());
          Queue jmsQ = jmsSession.createQueue(qData.getName());
@@ -293,7 +293,7 @@ public class JTBConnection {
       }
 
       boolean showSystemObjects = ps.getBoolean(Constants.PREF_SHOW_SYSTEM_OBJECTS);
-      DestinationData dd = qm.discoverDestinations(jmsConnection, showSystemObjects);
+      DestinationData dd = qm.discoverDestinations(jmsConnection, showSystemObjects, sessionDef);
 
       // Only process additions
       for (QueueData qData : dd.getListQueueData()) {

--- a/org.titou10.jtb.core/src/org/titou10/jtb/jms/qm/QManager.java
+++ b/org.titou10.jtb.core/src/org/titou10/jtb/jms/qm/QManager.java
@@ -65,7 +65,7 @@ public abstract class QManager implements JTBObject, Comparable<QManager> {
 
    public abstract Connection connect(SessionDef sessionDef, boolean showSystemObjects, String clientID) throws Exception;
 
-   public abstract DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception;
+   public abstract DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception;
 
    public abstract void close(Connection jmsConnection) throws JMSException;
 

--- a/org.titou10.jtb.qm.activemq/src/org/titou10/jtb/qm/activemq/ActiveMQQManager.java
+++ b/org.titou10.jtb.qm.activemq/src/org/titou10/jtb/qm/activemq/ActiveMQQManager.java
@@ -301,7 +301,7 @@ public class ActiveMQQManager extends QManager {
    }
 
    @Override
-   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception {
+   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception {
       SessionInfo sessionInfo = sessionsInfo.get(jmsConnection.hashCode());
       return sessionInfo.isUseJMX() ? withJMX(jmsConnection, showSystemObjects) : withoutJMX(jmsConnection, showSystemObjects);
    }

--- a/org.titou10.jtb.qm.artemis/src/org/titou10/jtb/qm/artemis/ActiveMQArtemisQManager.java
+++ b/org.titou10.jtb.qm.artemis/src/org/titou10/jtb/qm/artemis/ActiveMQArtemisQManager.java
@@ -198,7 +198,7 @@ public class ActiveMQArtemisQManager extends QManager {
    }
 
    @Override
-   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception {
+   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception {
       log.debug("discoverDestinations : {} - {}", jmsConnection, showSystemObjects);
 
       Integer hash = jmsConnection.hashCode();

--- a/org.titou10.jtb.qm.artemis2/src/org/titou10/jtb/qm/artemis2/ActiveMQArtemis2QManager.java
+++ b/org.titou10.jtb.qm.artemis2/src/org/titou10/jtb/qm/artemis2/ActiveMQArtemis2QManager.java
@@ -269,7 +269,7 @@ public class ActiveMQArtemis2QManager extends QManager {
    }
 
    @Override
-   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception {
+   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception {
 
       log.debug("discoverDestinations : {} - {}", jmsConnection, showSystemObjects);
 

--- a/org.titou10.jtb.qm.azuresb/src/org/titou10/jtb/qm/azuresb/AzureServiceBusQManager.java
+++ b/org.titou10.jtb.qm.azuresb/src/org/titou10/jtb/qm/azuresb/AzureServiceBusQManager.java
@@ -309,7 +309,7 @@ public class AzureServiceBusQManager extends QManager {
    }
 
    @Override
-   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception {
+   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception {
       log.debug("discoverDestinations : {} - {}", jmsConnection, showSystemObjects);
 
       Integer hash = jmsConnection.hashCode();

--- a/org.titou10.jtb.qm.hornetq/src/org/titou10/jtb/qm/hornetq/HornetQQManager.java
+++ b/org.titou10.jtb.qm.hornetq/src/org/titou10/jtb/qm/hornetq/HornetQQManager.java
@@ -169,7 +169,7 @@ public class HornetQQManager extends QManager {
    }
 
    @Override
-   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception {
+   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception {
       log.debug("discoverDestinations : {} - {}", jmsConnection, showSystemObjects);
 
       Integer hash = jmsConnection.hashCode();

--- a/org.titou10.jtb.qm.ibmmq/src/org/titou10/jtb/qm/ibmmq/MQQManager.java
+++ b/org.titou10.jtb.qm.ibmmq/src/org/titou10/jtb/qm/ibmmq/MQQManager.java
@@ -396,7 +396,7 @@ public class MQQManager extends QManager {
    }
 
    @Override
-   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception {
+   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception {
       log.debug("discoverDestinations : {} - {}", jmsConnection, showSystemObjects);
 
       Integer hash = jmsConnection.hashCode();

--- a/org.titou10.jtb.qm.liberty/src/org/titou10/jtb/qm/liberty/LibertyQManager.java
+++ b/org.titou10.jtb.qm.liberty/src/org/titou10/jtb/qm/liberty/LibertyQManager.java
@@ -216,7 +216,7 @@ public class LibertyQManager extends QManager {
    }
 
    @Override
-   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception {
+   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception {
       log.debug("discoverDestinations : {} - {}", jmsConnection, showSystemObjects);
 
       Integer hash = jmsConnection.hashCode();

--- a/org.titou10.jtb.qm.openmq/src/org/titou10/jtb/qm/openmq/OpenMQQManager.java
+++ b/org.titou10.jtb.qm.openmq/src/org/titou10/jtb/qm/openmq/OpenMQQManager.java
@@ -182,7 +182,7 @@ public class OpenMQQManager extends QManager {
    }
 
    @Override
-   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception {
+   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception {
       log.debug("discoverDestinations : {} - {}", jmsConnection, showSystemObjects);
 
       // Discover Queues and Topics

--- a/org.titou10.jtb.qm.rabbitmq/src/org/titou10/jtb/qm/rabbitmq/RabbitMQQManager.java
+++ b/org.titou10.jtb.qm.rabbitmq/src/org/titou10/jtb/qm/rabbitmq/RabbitMQQManager.java
@@ -93,7 +93,7 @@ public class RabbitMQQManager extends QManager {
    }
 
    @Override
-   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception {
+   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception {
       log.debug("discoverDestinations : {} - {}", jmsConnection, showSystemObjects);
 
       // Discover Queues and Topics

--- a/org.titou10.jtb.qm.solace/src/org/titou10/jtb/qm/solace/SolaceQManager.java
+++ b/org.titou10.jtb.qm.solace/src/org/titou10/jtb/qm/solace/SolaceQManager.java
@@ -326,7 +326,7 @@ public class SolaceQManager extends QManager {
    }
 
    @Override
-   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception {
+   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception {
       log.debug("discoverDestinations. showSystemObjects? {}", showSystemObjects);
 
       int hash = jmsConnection.hashCode();

--- a/org.titou10.jtb.qm.sonicmq/src/org/titou10/jtb/qm/sonicmq/SonicMQQManager.java
+++ b/org.titou10.jtb.qm.sonicmq/src/org/titou10/jtb/qm/sonicmq/SonicMQQManager.java
@@ -199,7 +199,7 @@ public class SonicMQQManager extends QManager {
 
    @Override
    @SuppressWarnings("unchecked")
-   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception {
+   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception {
       log.debug("discoverDestinations : {} - {}", jmsConnection, showSystemObjects);
 
       Integer hash = jmsConnection.hashCode();

--- a/org.titou10.jtb.qm.tibco/src/org/titou10/jtb/qm/tibco/TIBCOQManager.java
+++ b/org.titou10.jtb.qm.tibco/src/org/titou10/jtb/qm/tibco/TIBCOQManager.java
@@ -236,7 +236,7 @@ public class TIBCOQManager extends QManager {
    }
 
    @Override
-   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception {
+   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception {
       log.debug("discoverDestinations : {} - {}", jmsConnection, showSystemObjects);
 
       Integer hash = jmsConnection.hashCode();

--- a/org.titou10.jtb.qm.um/src/org/titou10/jtb/qm/um/UMQManager.java
+++ b/org.titou10.jtb.qm.um/src/org/titou10/jtb/qm/um/UMQManager.java
@@ -233,7 +233,7 @@ public class UMQManager extends QManager {
    }
 
    @Override
-   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception {
+   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception {
       log.debug("discoverDestinations : {} - {}", jmsConnection, showSystemObjects);
 
       Integer hash = jmsConnection.hashCode();

--- a/org.titou10.jtb.qm.wassib/src/org/titou10/jtb/qm/wassib/WASSIBQManager.java
+++ b/org.titou10.jtb.qm.wassib/src/org/titou10/jtb/qm/wassib/WASSIBQManager.java
@@ -203,7 +203,7 @@ public class WASSIBQManager extends QManager {
 
    @Override
    @SuppressWarnings("unchecked")
-   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception {
+   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception {
       log.debug("discoverDestinations : {} - {}", jmsConnection, showSystemObjects);
 
       Integer hash = jmsConnection.hashCode();

--- a/org.titou10.jtb.qm.weblogic/src/org/titou10/jtb/qm/weblogic/WebLogicQManager.java
+++ b/org.titou10.jtb.qm.weblogic/src/org/titou10/jtb/qm/weblogic/WebLogicQManager.java
@@ -264,7 +264,7 @@ public class WebLogicQManager extends QManager {
    }
 
    @Override
-   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception {
+   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception {
 
       Integer hash = jmsConnection.hashCode();
       MBeanServerConnection mbsc = mbscs.get(hash);

--- a/org.titou10.jtb.qm.websphere/src/org/titou10/jtb/qm/websphere/WASQManager.java
+++ b/org.titou10.jtb.qm.websphere/src/org/titou10/jtb/qm/websphere/WASQManager.java
@@ -159,7 +159,7 @@ public class WASQManager extends QManager {
    }
 
    @Override
-   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects) throws Exception {
+   public DestinationData discoverDestinations(Connection jmsConnection, boolean showSystemObjects, SessionDef sessionDef) throws Exception {
       log.debug("discoverDestinations : {} - {}", jmsConnection, showSystemObjects);
 
       Integer hash = jmsConnection.hashCode();


### PR DESCRIPTION
## New Features #184

## Description of proposed Change
In the change default the exception queues are visible. 
If the user doesn't want to view the exception queues then you have to set the property: showExceptionQueues to false.