### PR TITLE
JSON tree view for JMS message payload

### DIFF
--- a/org.titou10.jtb.core/src/org/titou10/jtb/ui/part/JTBMessageViewPart.java
+++ b/org.titou10.jtb.core/src/org/titou10/jtb/ui/part/JTBMessageViewPart.java
@@ -67,6 +67,7 @@ import org.eclipse.swt.widgets.TabItem;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.swt.widgets.Tree;
 import org.eclipse.wb.swt.SWTResourceManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,6 +114,12 @@ public class JTBMessageViewPart {
    private Text                 txtPayloadText;
    private Text                 txtPayloadXML;
    private Text                 txtPayloadJSON;
+   
+   private Tree                 treePayloadJSON;
+   
+   // Development switch. Decide if you want to use JSON view as tree (true) or text (false).
+   private static final boolean USE_JSON_TREE = true;
+   
    private HexViewer            hvPayLoadHex;
    private TableViewer          tvPayloadMap;
    private Table                tableProperties;
@@ -429,21 +436,30 @@ public class JTBMessageViewPart {
                tabPayloadJSON.setControl(composite1);
                composite1.setLayout(new FillLayout(SWT.HORIZONTAL));
 
-               // DF SWT.WRAP slows down A LOT UI for long text Messages (> 1K)
-               // txtPayloadXML = new Text(composite_1, SWT.READ_ONLY | SWT.WRAP | SWT.H_SCROLL | SWT.V_SCROLL | SWT.CANCEL);
-               txtPayloadJSON = new Text(composite1, SWT.READ_ONLY | SWT.H_SCROLL | SWT.V_SCROLL | SWT.CANCEL);
-               txtPayloadJSON.setBackground(SWTResourceManager.getColor(SWT.COLOR_LIST_BACKGROUND));
-
-               // Add key binding for CTRL-a -> select all
-               txtPayloadJSON.addListener(SWT.KeyUp, new Listener() {
-
-                  @Override
-                  public void handleEvent(Event event) {
-                     if ((event.stateMask == SWT.MOD1) && (event.keyCode == 'a')) {
-                        ((Text) event.widget).selectAll();
+               if (USE_JSON_TREE)
+               {
+                  treePayloadJSON = new Tree(composite1, SWT.READ_ONLY | SWT.H_SCROLL | SWT.V_SCROLL | SWT.CANCEL);
+                  treePayloadJSON.setBackground(SWTResourceManager.getColor(SWT.COLOR_LIST_BACKGROUND));   
+               }
+               else
+               {
+                  // DF SWT.WRAP slows down A LOT UI for long text Messages (> 1K)
+                  // txtPayloadXML = new Text(composite_1, SWT.READ_ONLY | SWT.WRAP | SWT.H_SCROLL | SWT.V_SCROLL | SWT.CANCEL);
+                  txtPayloadJSON = new Text(composite1, SWT.READ_ONLY | SWT.H_SCROLL | SWT.V_SCROLL | SWT.CANCEL);
+                  txtPayloadJSON.setBackground(SWTResourceManager.getColor(SWT.COLOR_LIST_BACKGROUND));
+   
+                  // Add key binding for CTRL-a -> select all
+                  txtPayloadJSON.addListener(SWT.KeyUp, new Listener() {
+   
+                     @Override
+                     public void handleEvent(Event event) {
+                        if ((event.stateMask == SWT.MOD1) && (event.keyCode == 'a')) {
+                           ((Text) event.widget).selectAll();
+                        }
                      }
-                  }
-               });
+                  });
+               }
+               
             }
 
             if (tabPayloadHex == null) {
@@ -469,9 +485,13 @@ public class JTBMessageViewPart {
 
             txtPayloadText.setText(CR_PATTERN.matcher(txt).replaceAll(CR));
             txtPayloadXML.setText(FormatUtils.xmlPrettyFormat(ps, txt, false));
-            txtPayloadJSON.setText(FormatUtils.jsonPrettyFormat(txt, false));
             hvPayLoadHex.setDataProvider(new BytesDataProvider(bytes));
-
+            
+            if (USE_JSON_TREE)
+               Json2TreeConverter.parseTree(treePayloadJSON, txt);
+            else
+               txtPayloadJSON.setText(FormatUtils.jsonPrettyFormat(txt, false)); 
+            
             break;
 
          case BYTES:
@@ -620,6 +640,7 @@ public class JTBMessageViewPart {
       tablePropertiesViewerComposite.layout();
       Utils.resizeTableViewer(tablePropertiesViewer);
    }
+
 
    private void setTabSelection(JTBMessageType jtbMessageType) {
 
@@ -848,5 +869,6 @@ public class JTBMessageViewPart {
 
       });
    }
+
 
 }

--- a/org.titou10.jtb.core/src/org/titou10/jtb/ui/part/Json2TreeConverter.java
+++ b/org.titou10.jtb.core/src/org/titou10/jtb/ui/part/Json2TreeConverter.java
@@ -1,0 +1,162 @@
+package org.titou10.jtb.ui.part;
+
+import java.io.StringReader;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonString;
+import jakarta.json.JsonStructure;
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonParsingException;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swt.widgets.TreeItem;
+
+
+/**
+ * Helper class to convert string as JSON and insert
+ * it into an SWT {@link Tree}.
+ * <pre>
+ * Tree tree = ...;
+ * String propablyJsonText = ...;
+ * 
+ * Json2TreeConverter.parseTree(treePayloadJSON, propablyJsonText);
+ * </pre>
+ * 
+ * @author Thomas Jancar (pmias)
+ * @version 1.0 - 25.09.2025
+ */
+public final class Json2TreeConverter {
+
+   /** No instance - only one public static method. */
+   private Json2TreeConverter() {}
+   
+   /**
+    * Parse a string as a JSON structure and convert
+    * it to a tree structure. If string cannot be parsed
+    * as JSON, a single tree item with an error message
+    * will be shown.
+    * 
+    * @param tree SWT tree.
+    * @param txt string (probably JSON)
+    */
+   public static void parseTree(Tree tree, String txt) {
+
+      // Remove all previous structures.
+      tree.removeAll();
+      
+      // Nothing to view.
+      if (null == txt || txt.isBlank()) return;
+
+      // The root item - either with the parsed JSON content or for error message.
+      TreeItem root = new TreeItem(tree, SWT.NONE);
+
+      // Parse string as JSON and insert it into root tree item.
+      // If string wasn't JSON, a JsonParsingException will be thrown;
+      // in this case, show an error message in the root tree item.
+      try {
+         JsonReader reader = Json.createReader(new StringReader(txt));
+         JsonStructure struct = reader.read();
+
+         insertJsonType(root, struct);
+      } catch (JsonParsingException e) {
+         root.removeAll();
+         // root.setText(e.toString());
+         root.setText("(No json tree to show. The payload was probably not valid json)");
+      }
+
+      expandAll(root, true);
+   }
+
+   
+   /**
+    * Expand or collapse a {@link TreeItem} and all its children.
+    * 
+    * @param treeItem tree item to expand/collapse.
+    * @param expand if true, expand; else collapse.
+    */
+   private static void expandAll(TreeItem treeItem, boolean expand) {
+      treeItem.setExpanded(expand);
+      for (TreeItem ti : treeItem.getItems())
+         expandAll(ti, expand);
+   }
+
+
+   /**
+    * Make new {@link TreeItem} with text.
+    * 
+    * @param parentItem parent tree item to add the new tree item as a child.
+    * @param text optional text of the new tree item.
+    * @return generated tree item.
+    */
+   private static TreeItem newItem(TreeItem parentItem, String text) {
+      TreeItem childItem = new TreeItem(parentItem, SWT.NONE);
+      if (null != text)
+         childItem.setText(text);
+      return childItem;
+   }
+
+   
+   /**
+    * Append a string with a space to an existing title of an {@link TreeItem}.
+    * 
+    * @param treeItem tree item to change the title.
+    * @param append append string for the title.
+    */
+   private static void appendTitle(TreeItem treeItem, String append) {
+      String txt = treeItem.getText();
+      txt = null == txt ? append : txt + ' ' + append;
+      treeItem.setText(txt);
+   }
+   
+
+   /**
+    * Append a {@link JsonValue} to a {@link TreeItem}, either as string value
+    * to its title or as a new child.
+    * 
+    * @param parentItem tree item to add the JSÖN value, depending on the value's type.
+    * @param jsonValue JSON value.
+    */
+   private static void insertJsonType(TreeItem parentItem, JsonValue jsonValue) {
+      switch (jsonValue.getValueType()) {
+         
+         // Add these JSON values into the parent's title.
+         case STRING:
+            appendTitle(parentItem, ((JsonString) jsonValue).getString());
+            break;
+
+         case NUMBER:
+            appendTitle(parentItem, jsonValue.toString());
+            break;
+
+         case FALSE: // fallthrough;
+         case TRUE:  // fallthrough;
+         case NULL:
+            appendTitle(parentItem, jsonValue.getValueType().toString());
+            break;
+
+         // Add array elements as new children.
+         case ARRAY:
+            JsonArray array = (JsonArray) jsonValue;
+            for (JsonValue val : array) {
+               TreeItem childItem = newItem(parentItem, "[ ]");
+               insertJsonType(childItem, val);
+            }
+            break;
+
+         // Add sub elements of JSON object as new childen.
+         case OBJECT:
+            JsonObject object = (JsonObject) jsonValue;
+            for (String key : object.keySet()) {
+               TreeItem childItem = newItem(parentItem, key + ':');
+               insertJsonType(childItem, object.get(key));
+            }
+            break;
+      }
+
+   }
+
+}


### PR DESCRIPTION
## Fixes bug...
none

## New Features ...
 JSON tree view for JMS message payload.

## Description of proposed Change
If JMS message payload is a valid JSON structure, it will be shown as a tree structure (SWT Tree) in tab "Payload (JSON)".
If the message was not a valid JSON structure, an error message will be shown, just like the XML view.
This is very helpful, when debugging JSON messages in queues with JMSToolBox.
Currently, this feature just replaces the former JSON text view, but can be switched by `org.titou10.jtb.ui.part.JTBMessageViewPart.USE_JSON_TREE = false`. It's up to the JMSToolBox-Team to decide, if it should act as a permanent replacement or probably implement some kind of switch between the two views.
